### PR TITLE
近一步完善 .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,30 @@
 ###############################################################################
 * text=auto
 
+# Make sure that these files always have CRLF line endings in checkout
+*.config          text eol=crlf
+*.cs              text eol=crlf
+*.csproj          text eol=crlf
+*.html            text eol=crlf
+*.js              text eol=crlf
+*.manifest        text eol=crlf
+*.resx            text eol=crlf
+*.sln             text eol=crlf
+*.targets         text eol=crlf
+*.txt             text eol=crlf
+*.vcxproj         text eol=crlf
+*.vcxproj.filters text eol=crlf
+*.xml             text eol=crlf
+*.xsd             text eol=crlf
+
+# Never perform LF normalization on these files
+*.chw    binary
+*.dll    binary
+*.docx   binary
+*.exe    binary
+*.ico    binary
+*.png    binary
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
@@ -34,15 +58,6 @@
 #*.modelproj merge=binary
 #*.sqlproj   merge=binary
 #*.wwaproj   merge=binary
-
-###############################################################################
-# behavior for image files
-#
-# image files are treated as binary by default.
-###############################################################################
-#*.jpg   binary
-#*.png   binary
-#*.gif   binary
 
 ###############################################################################
 # diff behavior for common document formats


### PR DESCRIPTION
在 .gitattributes 中定义项目中各类文件为文本文件还是二进制文件，
以免当文本文件过大时，某些工具会误认为为二进制文件，不能展示
差异比较。并且因平台和不同编辑器的差异可能会意外修改换行，被
Git 感知从而引入无必要的格式差异。

目前除了 C/C++ 和 md 文件未定义，其他文件均定义了文件类型
(文本/二进制) 以及换行格式。

C/C++ 文件目前存在两种不同换行格式，原始为 LF 换行，后面使用编辑器
编辑后转变了部分文件的换行。后续进行统一为 LF 后，再继续完善此文件。

> 另外，建议用 `Rebase and merge` 而非 `Create a merge commit` 的方式合并 PR，以免产生很多无必要的分支合并在版本中。每个提交合并入库时都实际产生了两个提交，提交历史看上去感觉有些花。