### PR TITLE
屏蔽 jbig2 的编译警告

### DIFF
--- a/JBig2/jbig2.vcxproj
+++ b/JBig2/jbig2.vcxproj
@@ -141,7 +141,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;__STDC_LIMIT_MACROS;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>-w24146 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-w44146 -w44244 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,7 +158,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;__STDC_LIMIT_MACROS;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>-w24146 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-w44146 -w44244 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
因使用原始代码，无需修改，故屏蔽警告。