### PR TITLE
微调部分文本

### DIFF
--- a/App/Functions/AboutPage.html
+++ b/App/Functions/AboutPage.html
@@ -47,7 +47,7 @@ span {
 					<td><a href="$AppHomePage">$AppHomePage</a></td>
 				</tr>
 				<tr>
-					<td>源代码网址：</td>
+					<td>源码网址：</td>
 					<td><a href="$AppHubPage">$AppHubPage</a></td>
 				</tr>
 				<tr>

--- a/App/Functions/ExtractImageControl.resx
+++ b/App/Functions/ExtractImageControl.resx
@@ -121,7 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="textBox1.Text" xml:space="preserve">
-    <value>页码范围说明；
+    <value>页码范围说明：
 　　页码范围表示需处理的原始 PDF 文档页面。
 　　不指定页码范围时，提取源文件所有页面的内容。
 　　如有多个页码，可用“,”或“ ”（空格）隔开。


### PR DESCRIPTION
* "源代码网址" 改为 "源码网址"， 上下全为四字对齐更工整。
* “页面范围说明” 后面的分号为笔误，修改为冒号。