### PR TITLE
将部分参数类型替换为 IEnumerable<T>

### DIFF
--- a/App/AppContext.cs
+++ b/App/AppContext.cs
@@ -283,7 +283,7 @@ namespace PDFPatcher
 			File.WriteAllText(path, Json.ToJson(s, JsonSm), Encoding.UTF8);
 		}
 
-		private static void WriteRecentFiles(XmlWriter writer, IList<string> list, string name) {
+		private static void WriteRecentFiles(XmlWriter writer, IEnumerable<string> list, string name) {
 			foreach (var item in list) {
 				writer.WriteStartElement(name);
 				writer.WriteAttributeString(Configuration.Path, item);

--- a/App/MainForm.cs
+++ b/App/MainForm.cs
@@ -310,7 +310,7 @@ namespace PDFPatcher
 #endif
 		}
 
-		void OpenFiles(string[] files) {
+		void OpenFiles(IEnumerable<string> files) {
 			foreach (var item in files) {
 				var p = new FilePath(item);
 				if (p.ExistsFile && p.HasExtension(Constants.FileExtensions.Pdf)) {


### PR DESCRIPTION
此更改的优点是使读者知悉该函数本身仅迭代集合并且不访问任何非 IEnumerable 成员。