### PR TITLE
解决“添加字体筛选条件”对话框因为信息文件没有包含字体信息时导致崩溃的问题

### DIFF
--- a/App/Functions/AutoBookmark/FontFilterForm.cs
+++ b/App/Functions/AutoBookmark/FontFilterForm.cs
@@ -98,8 +98,10 @@ namespace PDFPatcher.Functions
 			foreach (XmlElement item in _FontInfoBox.Roots) {
 				_FontInfoBox.Expand(item);
 			}
-			_FontInfoBox.EnsureVisible(0);
-			_FontInfoBox.Sort(_CountColumn, SortOrder.Descending);
+			if (_FontInfoBox.GetItemCount() > 0) {
+				_FontInfoBox.EnsureVisible(0);
+				_FontInfoBox.Sort(_CountColumn, SortOrder.Descending);
+			}
 		}
 
 		void _OkButton_Click(Object source, EventArgs args) {


### PR DESCRIPTION
如果选择的信息文件没有字体信息，如：<文档字体 />
第 100 行的代码 _FontInfoBox.EnsureVisible(0); 会引起崩溃。