### PR TITLE
更新工程配置为目前 .NET Framework 支持操作系统最多的版本（4.8）

### DIFF
--- a/App/PDFPatcher.csproj
+++ b/App/PDFPatcher.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PDFPatcher</RootNamespace>
     <AssemblyName>PDFPatcher</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>pdf_icon.ico</ApplicationIcon>
     <SignAssembly>true</SignAssembly>

--- a/App/app.config
+++ b/App/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
 <startup>
-	<supportedRuntime version="v4.0"/>
+	<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
 </startup>
 </configuration>


### PR DESCRIPTION
为了解决 README 中`运行环境`所描述的问题。
更新工程配置为目前 .NET Framework 支持操作系统最多的版本（4.8）。
这样 VS2019-2022 全部支持且不会提示更新目标。
参考链接：https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies